### PR TITLE
Integrate Continuous Building using GitHub Actions  (closes #7)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,22 @@
+name: Build
+on:
+  - pull_request
+  - push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install CMake
+        uses: jwlawson/actions-setup-cmake@v1.7
+        with:
+          cmake-version: '3.10.x'
+
+      - name: Build
+        run: |
+          mkdir -p build/debug && cd build/debug &&
+          cmake -DCMAKE_MAKE_PROGRAM=make -DCMAKE_C_COMPILER=gcc-9 -DCMAKE_BUILD_TYPE=Debug ../.. &&
+          make --no-print-directory all


### PR DESCRIPTION
Integration is seamless for the time being. However, there might be issues around the kernel version in the future. So the action is subject to change in the near future.