### PR TITLE
Implement Signal Handling (closes #13)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(
 
     src/main.c
     src/result.c
+    src/signal.c
     src/stack.c
     src/status.c
 )
@@ -36,6 +37,8 @@ target_compile_options(
 )
 
 target_include_directories(encin PUBLIC include)
+
+target_link_libraries(encin PUBLIC pthread)
 
 if (CMAKE_PROJECT_NAME STREQUAL encin)
     add_subdirectory(examples)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,3 +1,18 @@
+add_executable(handling-signals handling-signals.c)
+
+set_target_properties(
+    handling-signals
+
+    PROPERTIES
+
+    C_STANDARD 11
+    C_STANDARD_REQUIRED ON
+    C_EXTENSIONS ON
+)
+
+target_link_libraries(handling-signals PRIVATE encin)
+
+
 add_executable(runtime-information runtime-information.c)
 
 set_target_properties(

--- a/examples/handling-signals.c
+++ b/examples/handling-signals.c
@@ -14,12 +14,11 @@ int encin(void) {
     size_t press_count = 0;
     encin_signal(SIGINT, sigint_handler, &press_count);
 
-    while (atomic_load_explicit(&press_count, memory_order_relaxed) < 42) {
-        printf(
-            "You pressed CTRL+C %zu times...\n",
-            atomic_load_explicit(&press_count, memory_order_relaxed)
-        );
+    size_t local_press_count = atomic_load_explicit(&press_count, memory_order_relaxed);
+    while (local_press_count < 42) {
+        printf("You pressed CTRL+C %zu times...\n", local_press_count);
         usleep(100000);
+        local_press_count = atomic_load_explicit(&press_count, memory_order_relaxed);
     }
 
     return 0;

--- a/examples/handling-signals.c
+++ b/examples/handling-signals.c
@@ -7,32 +7,19 @@ void sigint_handler(struct signalfd_siginfo *info, void *argument) {
     (void)info;
 
     size_t *press_count_pointer = argument;
-    switch (atomic_fetch_add_explicit(press_count_pointer, 1, memory_order_relaxed)) {
-        case 0: {
-            printf("You pressed CTRL+C for the first time...\n");
-            break;
-        }
-        case 1: {
-            printf("You pressed CTRL+C for the second time...\n");
-            break;
-        }
-        case 2: {
-            printf("You pressed CTRL+C for the third time...\n");
-            printf("  Fine I'll quit. Sheesh...\n");
-            break;
-        }
-        default: {
-            break;
-        }
-    }
+    atomic_fetch_add_explicit(press_count_pointer, 1, memory_order_relaxed);
 }
 
 int encin(void) {
     size_t press_count = 0;
     encin_signal(SIGINT, sigint_handler, &press_count);
 
-    while (atomic_load_explicit(&press_count, memory_order_relaxed) < 3) {
-        usleep(100);
+    while (atomic_load_explicit(&press_count, memory_order_relaxed) < 42) {
+        printf(
+            "You pressed CTRL+C %zu times...\n",
+            atomic_load_explicit(&press_count, memory_order_relaxed)
+        );
+        usleep(100000);
     }
 
     return 0;

--- a/examples/handling-signals.c
+++ b/examples/handling-signals.c
@@ -1,0 +1,39 @@
+#include <encin.h>
+#include <stdatomic.h>
+#include <stdio.h>
+#include <unistd.h>
+
+void sigint_handler(struct signalfd_siginfo *info, void *argument) {
+    (void)info;
+
+    size_t *press_count_pointer = argument;
+    switch (atomic_fetch_add_explicit(press_count_pointer, 1, memory_order_relaxed)) {
+        case 0: {
+            printf("You pressed CTRL+C for the first time...\n");
+            break;
+        }
+        case 1: {
+            printf("You pressed CTRL+C for the second time...\n");
+            break;
+        }
+        case 2: {
+            printf("You pressed CTRL+C for the third time...\n");
+            printf("  Fine I'll quit. Sheesh...\n");
+            break;
+        }
+        default: {
+            break;
+        }
+    }
+}
+
+int encin(void) {
+    size_t press_count = 0;
+    encin_signal(SIGINT, sigint_handler, &press_count);
+
+    while (atomic_load_explicit(&press_count, memory_order_relaxed) < 3) {
+        usleep(100);
+    }
+
+    return 0;
+}

--- a/include/encin/signal.h
+++ b/include/encin/signal.h
@@ -1,8 +1,23 @@
 #pragma once
 
+#include <encin/stack.h>
 #include <signal.h>
 #include <sys/signalfd.h>
 
 typedef void (*encin_signal_handler)(struct signalfd_siginfo *info, void *argument);
 
 void encin_signal(int signal, encin_signal_handler handler, void *argument);
+
+
+#ifndef ENCIN_SIGNAL_LISTENER_STACK_SIZE
+#define ENCIN_SIGNAL_LISTENER_STACK_SIZE (ENCIN_STACK_32K)
+#endif
+static_assert(
+    ENCIN_SIGNAL_LISTENER_STACK_SIZE >= ENCIN_STACK_16K
+    && ENCIN_SIGNAL_LISTENER_STACK_SIZE <= ENCIN_STACK_4G,
+    "ENCIN_SIGNAL_LISTENER_STACK_SIZE is not an instance of encin_stack_size"
+);
+
+int encin_signal_start_listener(void);
+
+void encin_signal_stop_listener(void);

--- a/src/main.c
+++ b/src/main.c
@@ -1,5 +1,48 @@
+#include <encin.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sysexits.h>
+
 extern int encin();
 
 int main(int argc, char *argv[], char *envp[]) {
-    return encin(argc, argv, envp);
+    #define RED(string) "\x1B[31m" string "\x1B[0m"
+
+    int result = encin_signal_start_listener();
+    if (result != 0) {
+        switch (result) {
+            case -1: {
+                fprintf(
+                    stderr,
+                    RED("fatal encin error:")" signal file creation failed (%s)\n",
+                    strerror(errno)
+                );
+                fflush(stderr);
+                break;
+            }
+            case -2: {
+                fprintf(
+                    stderr,
+                    RED("fatal encin error:")" signal listener creation failed (%s)\n",
+                    strerror(errno)
+                );
+                fflush(stderr);
+                break;
+            }
+            default: {
+                __builtin_unreachable();
+            }
+        }
+        goto SIGNAL_START_LISTENER_FAILED;
+    }
+
+    int code = encin(argc, argv, envp);
+
+    encin_signal_stop_listener();
+    return code;
+
+    SIGNAL_START_LISTENER_FAILED:
+    exit(EX_OSERR);
 }

--- a/src/signal.c
+++ b/src/signal.c
@@ -1,0 +1,124 @@
+#include <assert.h>
+#include <encin.h>
+#include <errno.h>
+#include <pthread.h>
+#include <signal.h>
+#include <stdatomic.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <sys/signalfd.h>
+#include <unistd.h>
+
+
+static pid_t pid = 0;
+static pthread_t tid = 0;
+static int fd = 0;
+
+static encin_signal_handler handlers[NSIG] = { NULL };
+static void *arguments[NSIG] = { NULL };
+
+static void *signal_listener(void *unused) {
+    (void)unused;
+
+    bool stopped = false;
+    while (!stopped) {
+        struct signalfd_siginfo caught_signal_infos[16];
+        ssize_t read_bytes = read(fd, &caught_signal_infos, 16 * sizeof(struct signalfd_siginfo));
+        if (read_bytes == -1) {
+            continue;
+        }
+
+        size_t caught_signal_count = read_bytes / sizeof(struct signalfd_siginfo);
+        for (size_t i = 0; i < caught_signal_count; i++) {
+            struct signalfd_siginfo *caught_signal_info = &caught_signal_infos[i];
+
+            uint32_t caught_signal_no = caught_signal_info->ssi_signo;
+            pid_t caught_signal_sender_pid = caught_signal_info->ssi_pid;
+
+            if (caught_signal_sender_pid == pid && caught_signal_no == SIGUSR2) {
+                stopped = true;
+                break;
+            }
+
+            encin_signal_handler handler
+                = atomic_load_explicit(&handlers[caught_signal_no], memory_order_acquire);
+            if (handler != NULL) {
+                void *argument = arguments[caught_signal_no];
+                handler(caught_signal_info, argument);
+            }
+        }
+    }
+
+    return NULL;
+}
+
+
+void encin_signal(int signal, encin_signal_handler handler, void *argument) {
+    assert(
+        "(encin usage error on encin_set_signal_handler: signal does not exist)"
+            && (signal > 0 && signal < NSIG)
+    );
+
+    arguments[signal] = argument;
+    atomic_store_explicit(&handlers[signal], handler, memory_order_release);
+}
+
+int encin_signal_start_listener(void) {
+    sigset_t all_signals;
+    sigfillset(&all_signals);
+    sigprocmask(SIG_BLOCK, &all_signals, NULL);
+
+    pid = getpid();
+
+    fd = signalfd(-1, &all_signals, SFD_CLOEXEC);
+    if (fd == -1) {
+        sigprocmask(SIG_UNBLOCK, &all_signals, NULL);
+        return -1;
+    }
+
+    pthread_attr_t signal_listener_attributes;
+    int result = pthread_attr_init(&signal_listener_attributes);
+    if (result != 0) {
+        close(fd);
+        sigprocmask(SIG_UNBLOCK, &all_signals, NULL);
+
+        errno = result;
+        return -2;
+    }
+
+    size_t stack_size = 1 << ENCIN_SIGNAL_LISTENER_STACK_SIZE;
+    result = pthread_attr_setstacksize(&signal_listener_attributes, stack_size);
+    if (result != 0) {
+        pthread_attr_destroy(&signal_listener_attributes);
+        close(fd);
+        sigprocmask(SIG_UNBLOCK, &all_signals, NULL);
+
+        errno = result;
+        return -2;
+    }
+
+    result = pthread_create(&tid, &signal_listener_attributes, signal_listener, NULL);
+    if (result != 0) {
+        pthread_attr_destroy(&signal_listener_attributes);
+        close(fd);
+        sigprocmask(SIG_UNBLOCK, &all_signals, NULL);
+
+        errno = result;
+        return -2;
+    }
+    pthread_attr_destroy(&signal_listener_attributes);
+
+    return 0;
+}
+
+void encin_signal_stop_listener(void) {
+    kill(pid, SIGUSR2);
+    pthread_join(tid, NULL);
+
+    close(fd);
+
+    sigset_t all_signals;
+    sigfillset(&all_signals);
+    sigprocmask(SIG_UNBLOCK, &all_signals, NULL);
+}


### PR DESCRIPTION
The implementation uses a background thread to catch signals using [signalfd](https://linux.die.net/man/2/signalfd) and call appropriate handlers with appropriate arguments.